### PR TITLE
Show actual subtotal and prices

### DIFF
--- a/src/components/CartDrawer.svelte
+++ b/src/components/CartDrawer.svelte
@@ -216,7 +216,7 @@
                       <p>Subtotal</p>
                       <p>
                         <Money
-                          price={$cart.cost.totalAmount}
+                          price={$cart.cost.subtotalAmount}
                           showCurrency={true}
                         />
                       </p>

--- a/src/components/Money.svelte
+++ b/src/components/Money.svelte
@@ -9,7 +9,7 @@
     style: "currency",
     currency: price.currencyCode,
     currencyDisplay: showCurrency ? "symbol" : "narrowSymbol",
-  }).format(parseInt(price.amount));
+  }).format(parseFloat(price.amount));
 </script>
 
 <span>

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -20,7 +20,7 @@ const emptyCart = {
   checkoutUrl: "",
   totalQuantity: 0,
   lines: { nodes: [] },
-  cost: { totalAmount: { amount: "", currencyCode: "" } },
+  cost: { subtotalAmount: { amount: "", currencyCode: "" } },
 };
 
 // Cart store with persistent state (local storage) and initial value

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -4,7 +4,7 @@ fragment cartFragment on Cart {
   totalQuantity
   checkoutUrl
   cost {
-    totalAmount {
+    subtotalAmount {
       amount
       currencyCode
     }

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -44,7 +44,7 @@ export const CartResult = z
   .object({
     id: z.string(),
     cost: z.object({
-      totalAmount: MoneyV2Result,
+      subtotalAmount: MoneyV2Result,
     }),
     checkoutUrl: z.string(),
     totalQuantity: z.number().int(),


### PR DESCRIPTION
Hi! I'm not sure if you're taking suggestions on this project but I wanted to share just in case...

As a store owner, I'm only ever going to show the subtotal in the cart, before the customer goes to checkout. Right now, the cart _says_ it's showing the subtotal but is actually showing the `totalAmount`, which includes taxes. 

The `Money` component is also rounding prices wherever they show up. That isn't an issue for my store because all our prices are in whole dollars but it made figuring out why the subtotal was wrong more confusing because it wasn't usually _quite_ showing the correct total including taxes. For most people, rounding prices and then actually charging something else isn't an option. 

If you're open to it, I'm happy to share other thoughts as I build with this. Thanks for the starter!