### PR TITLE
Allow item quantity update from cart

### DIFF
--- a/src/components/CartDrawer.svelte
+++ b/src/components/CartDrawer.svelte
@@ -4,6 +4,7 @@
     cart,
     isCartDrawerOpen,
     removeCartItems,
+    updateCartItems,
     isCartUpdating,
   } from "../stores/cart";
   import ShopifyImage from "./ShopifyImage.svelte";
@@ -27,6 +28,13 @@
 
   function removeItem(id: string) {
     removeCartItems([id]);
+  }
+
+  function updateItemQuantity() {
+    let lines = $cart.lines?.nodes.map(item => {
+      return { id: item.id, quantity: item.quantity}
+    })
+    updateCartItems(lines);
   }
 
   function closeCartDrawer() {
@@ -152,10 +160,10 @@
                               class="hover:underline w-fit"
                               href={`/products/${item.merchandise.product.handle}`}
                             >
-                              {item.merchandise.product.title}
+                              {item.merchandise.product.title} - <Money price={item.cost.amountPerQuantity} />
                             </a>
                             <p class="text-xs">
-                              <Money price={item.cost.amountPerQuantity} />
+                              <label>Quantity: <input type="number" bind:value={item.quantity} /></label> 
                             </p>
                           </div>
                           <div
@@ -209,9 +217,23 @@
 
               <div class="">
                 {#if $cart && $cart.lines?.nodes.length > 0}
-                  <div class="border-t border-zinc-200 py-6 px-4 sm:px-6">
+                  <div class="border-t border-zinc-200 py-4 px-4 sm:px-6">
+
+                    <div class="mt-6">
+                      <button 
+                        class="button w-full"
+                        type="button"
+                        disabled={$isCartUpdating}
+                        on:click={() => {
+                          updateItemQuantity();
+                        }}
+                      >
+                        Update Cart
+                      </button>
+                      <a href="/" class="button mt-4">Continue Shopping</a>
+                    </div>
                     <div
-                      class="flex justify-between text-base font-medium text-gray-900"
+                      class="flex justify-between text-base font-medium text-gray-900 mt-6"
                     >
                       <p>Subtotal</p>
                       <p>

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -6,6 +6,7 @@ import {
   addCartLines,
   createCart,
   removeCartLines,
+  updateCartLines,
 } from "../utils/shopify";
 import type { CartResult } from "../utils/schemas";
 
@@ -110,6 +111,29 @@ export async function removeCartItems(lineIds: string[]) {
 
   if (cartId) {
     const cartData = await removeCartLines(cartId, lineIds);
+
+    if (cartData) {
+      cart.set({
+        ...cart.get(),
+        id: cartData.id,
+        cost: cartData.cost,
+        checkoutUrl: cartData.checkoutUrl,
+        totalQuantity: cartData.totalQuantity,
+        lines: cartData.lines,
+      });
+      isCartUpdating.set(false);
+    }
+  }
+}
+
+export async function updateCartItems(lines: object[]) {
+  const localCart = cart.get();
+  const cartId = localCart?.id;
+
+  isCartUpdating.set(true);
+
+  if (cartId) {
+    const cartData = await updateCartLines(cartId, lines);
 
     if (cartData) {
       cart.set({

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -166,3 +166,31 @@ export const RemoveCartLinesMutation = `#graphql
   }
   ${CART_FRAGMENT}
 `;
+
+export const UpdateCartLinesMutation = `#graphql
+  mutation ($cartId: ID!, $lines:[CartLineUpdateInput!]!) {
+    cartLinesUpdate(cartId: $cartId, lines: $lines) {
+      cart {
+        ...cartFragment
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+  ${CART_FRAGMENT}
+`;
+
+export const SearchProductsQuery = `#graphql
+  query searchProducts($query: String!, $first: Int) {
+    search(query: $query, first: $first, types: PRODUCT) {
+      edges {
+        node {
+          ...productFragment
+        }
+      }
+    }
+  }
+  ${PRODUCT_FRAGMENT}
+`;

--- a/src/utils/shopify.ts
+++ b/src/utils/shopify.ts
@@ -8,6 +8,7 @@ import {
   AddCartLinesMutation,
   GetCartQuery,
   RemoveCartLinesMutation,
+  UpdateCartLinesMutation,
   ProductRecommendationsQuery,
 } from "./graphql";
 
@@ -167,6 +168,18 @@ export const removeCartLines = async (id: string, lineIds: string[]) => {
   });
   const { cartLinesRemove } = data;
   const { cart } = cartLinesRemove;
+  const parsedCart = CartResult.parse(cart);
+
+  return parsedCart;
+};
+
+export const updateCartLines = async (id: string, lines: object[]) => {
+  const data = await makeShopifyRequest(UpdateCartLinesMutation, {
+    cartId: id,
+    lines,
+  });
+  const { cartLinesUpdate } = data;
+  const { cart } = cartLinesUpdate;
   const parsedCart = CartResult.parse(cart);
 
   return parsedCart;


### PR DESCRIPTION
I'd like customers to be able to purchase multiples of a single item without having to navigate back to the product page for each unit. They should also be able to remove only some units of each item from their cart vs. the entire line.

I tossed some styles in there but I'm not married to them. Please feel free to edit whatever you like!